### PR TITLE
Exception in managed thread now prints full stack trace

### DIFF
--- a/src/main/java/org/glassfish/enterprise/concurrent/ManagedThreadFactoryImpl.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/ManagedThreadFactoryImpl.java
@@ -228,7 +228,7 @@ public class ManagedThreadFactoryImpl implements ManagedThreadFactory {
             } catch (ThreadExpiredException ex) {
                 Logger.getLogger("org.glassfish.enterprise.concurrent").log(Level.INFO, ex.toString());
             } catch (Throwable t) {
-                Logger.getLogger("org.glassfish.enterprise.concurrent").log(Level.SEVERE, t.toString());
+                Logger.getLogger("org.glassfish.enterprise.concurrent").log(Level.SEVERE, name, t);
             } finally {
                 if (handle != null) {
                     contextSetupProvider.reset(handle);


### PR DESCRIPTION
Currently when an exception is thrown in a managed thread all that is printed out is the name of the exception with no further details. This makes it so that if a managed thread throws an exception than the name of the thread and the full stack trace will be printed.