### PR TITLE
Fix version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish</groupId>
     <artifactId>jakarta.enterprise.concurrent</artifactId>
-    <version>3.0.0-RC1</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>org.glassfish.jakarta.enterprise.concurrent</name>
     <description>Compatible Implementation of Jakarta Concurrency</description>

--- a/src/main/java/org/glassfish/enterprise/concurrent/ManagedThreadFactoryImpl.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/ManagedThreadFactoryImpl.java
@@ -46,7 +46,7 @@ public class ManagedThreadFactoryImpl implements ManagedThreadFactory {
     private Lock lock; // protects threads and stopped
 
     private String name;
-    final protected ContextSetupProvider contextSetupProvider;
+    final private ContextSetupProvider contextSetupProvider;
     // A non-null ContextService should be provided if thread context should
     // be setup before running the Runnable passed in through the newThread
     // method.
@@ -228,6 +228,16 @@ public class ManagedThreadFactoryImpl implements ManagedThreadFactory {
       finally {
           lock.unlock();
       }
+    }
+
+    /**
+     * Make contextSetupProvider available for extending classes if necessary to implement context saving in other
+     * moments than this implemention expects.
+     *
+     * @return contextSetupProvider
+     */
+    protected ContextSetupProvider getContextSetupProvider() {
+        return contextSetupProvider;
     }
 
     @Override


### PR DESCRIPTION
Fixed version number back to -SNAPSHOT, so it can be built by Jenkins build.

Also added the change requested by @arjantijms in the last PR.