### PR TITLE
Updating and tidying pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2022 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -17,7 +19,6 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -30,11 +31,15 @@
     <artifactId>jakarta.enterprise.concurrent</artifactId>
     <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
+
     <name>org.glassfish.jakarta.enterprise.concurrent</name>
     <description>Compatible Implementation of Jakarta Concurrency</description>
     <url>https://projects.eclipse.org/projects/ee4j.cu</url>
-
-     <licenses>
+    <organization>
+        <name>Oracle Corporation</name>
+        <url>http://www.oracle.com/</url>
+    </organization>
+    <licenses>
         <license>
             <name>EPL 2.0</name>
             <url>http://www.eclipse.org/legal/epl-2.0</url>
@@ -47,11 +52,6 @@
         </license>
     </licenses>
 
-    <scm>
-        <url>https://github.com/eclipse-ee4j/concurrency-ri</url>
-        <connection>scm:git:https://github.com/eclipse-ee4j/concurrency-ri.git</connection>
-        <developerConnection>scm:git:git@github.com:eclipse-ee4j/concurrency-ri.git</developerConnection>
-    </scm>
     <developers>
         <developer>
             <id>anthony.lai</id>
@@ -65,14 +65,6 @@
         </developer>
     </developers>
 
-    <organization>
-        <name>Oracle Corporation</name>
-        <url>http://www.oracle.com/</url>
-    </organization>
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/eclipse-ee4j/concurrency-ri/issues</url>
-    </issueManagement>
     <mailingLists>
         <mailingList>
             <name>Concurrency mailing list</name>
@@ -83,29 +75,36 @@
         </mailingList>
     </mailingLists>
 
+    <scm>
+        <url>https://github.com/eclipse-ee4j/concurrency-ri</url>
+        <connection>scm:git:https://github.com/eclipse-ee4j/concurrency-ri.git</connection>
+        <developerConnection>scm:git:git@github.com:eclipse-ee4j/concurrency-ri.git</developerConnection>
+    </scm>
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/eclipse-ee4j/concurrency-ri/issues</url>
+    </issueManagement>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.release>11</maven.compiler.release>
         <jakarta.enterprise.concurrent-api.version>3.0.0</jakarta.enterprise.concurrent-api.version>
     </properties>
 
-
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>jakarta.enterprise.concurrent</groupId>
             <artifactId>jakarta.enterprise.concurrent-api</artifactId>
             <version>${jakarta.enterprise.concurrent-api.version}</version>
         </dependency>
+        
         <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.1.0</version>
-            <type>jar</type>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -115,87 +114,42 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.10.1</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.1</version>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M7</version>
                 </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit4</artifactId>
-                        <version>3.0.0-M5</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <archive>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
-                <configuration>
-                    <doctitle>Jakarta Concurrency Compatible Implementation ${project.version}</doctitle>
-                    <bottom>
-<![CDATA[Copyright (c) 2020 Eclipse Foundation.
-    Use is subject to
-    <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
-]]>
-                    </bottom>
-                    <excludePackageNames>org.glassfish.enterprise.concurrent.management</excludePackageNames>
-                    <source>1.8</source>
-                </configuration>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
-                        <id>attach-javadocs</id>
+                        <id>enforce-maven</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>enforce</goal>
                         </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.6.0</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Creates the OSGi MANIFEST.MF file -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-           <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>5.1.4</version>
                 <configuration>
                     <!-- By default, we don't export anything.
                     -->
@@ -214,94 +168,57 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Adds the manifest file created by the org.apache.felix:maven-bundle-plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
                 <configuration>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                    <useReleaseProfile>false</useReleaseProfile>
-                 <arguments>${release.arguments}</arguments>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <quiet>true</quiet>
+                    <doctitle>Jakarta Concurrency Compatible Implementation ${project.version}</doctitle>
+                    <bottom>
+                        <![CDATA[Copyright (c) 2020, 2022 Eclipse Foundation.
+    Use is subject to
+    <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
+]]>
+                    </bottom>
+                    <excludePackageNames>org.glassfish.enterprise.concurrent.management</excludePackageNames>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-
     </build>
-
-    <profiles>
-        <profile>
-            <id>re-build</id>
-            <activation>
-                <property>
-                    <name>license.url</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>wagon-maven-plugin</artifactId>
-                        <version>1.0-beta-4</version>
-                        <inherited>false</inherited>
-                        <executions>
-                            <execution>
-                                <id>get-license</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>download-single</goal>
-                                </goals>
-                                <configuration>
-                                    <url>${license.url}</url>
-                                    <fromFile>TLDA_SCSL_Licensees_License_Notice.txt</fromFile>
-                                    <toDir>${project.build.directory}/license</toDir>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <inherited>false</inherited>
-                        <executions>
-                            <execution>
-                                <id>make-licensee-src-assembly</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <configuration>
-                                    <finalName>javax.enterprise.concurrent-${project.version}-sources-licensee</finalName>
-                                    <attach>false</attach>
-                                    <appendAssemblyId>false</appendAssemblyId>
-                                    <descriptors>
-                                        <descriptor>src/main/assembly/assembly-src-licensee.xml</descriptor>
-                                    </descriptors>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/src/main/java/org/glassfish/enterprise/concurrent/AsynchronousInterceptor.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/AsynchronousInterceptor.java
@@ -15,25 +15,28 @@
  */
 package org.glassfish.enterprise.concurrent;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.glassfish.enterprise.concurrent.internal.ManagedCompletableFuture;
+
 import jakarta.annotation.Priority;
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import org.glassfish.enterprise.concurrent.internal.ManagedCompletableFuture;
 
 /**
  * Interceptor for @Asynchronous.
  *
- * @author Petr Aubrecht <aubrecht@asoftware.cz>
+ * @author Petr Aubrecht &lt;aubrecht@asoftware.cz&gt;
  */
 @Interceptor
 @Asynchronous

--- a/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedCompletableFuture.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedCompletableFuture.java
@@ -15,7 +15,6 @@
  */
 package org.glassfish.enterprise.concurrent.internal;
 
-import jakarta.enterprise.concurrent.ManagedExecutorService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -24,10 +23,12 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+
 /**
  * Managed CompletableFuture, using the provided ManagedExecutorServiceImpl.
  *
- * @author Petr Aubrecht <aubrecht@asoftware.cz>
+ * @author Petr Aubrecht &lt;aubrecht@asoftware.cz&gt;
  */
 public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
 
@@ -126,7 +127,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     public static <U> CompletionStage<U> completedStage(U value, ManagedExecutorService executor) {
         ManagedCompletableFuture<U> future = new ManagedCompletableFuture<>(executor);
         future.complete(value);
-        return (CompletionStage<U>) future;
+        return future;
     }
 
     public static <U> CompletableFuture<U> failedFuture(Throwable ex, ManagedExecutorService executor) {


### PR DESCRIPTION
* Update versions in pom
* Set to JDK 11
* Add enforcer for defined Maven version
* Remove old staging/build profiles (now done in EE4J parent)
* Removed unused dependency

Updated javadoc that prevented building on JDK 11 and JDK 17.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>