### PR TITLE
Remove invocation exception from exception causes

### DIFF
--- a/src/main/java/org/glassfish/enterprise/concurrent/internal/ContextProxyInvocationHandler.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/internal/ContextProxyInvocationHandler.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.concurrent.ManagedTask;
+import java.lang.reflect.InvocationTargetException;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
 import org.glassfish.enterprise.concurrent.spi.ContextHandle;
 import org.glassfish.enterprise.concurrent.spi.ContextSetupProvider;
@@ -80,6 +81,9 @@ public class ContextProxyInvocationHandler implements InvocationHandler, Seriali
             ContextHandle contextHandleForReset = contextSetupProvider.setup(capturedContextHandle);
             try {
                 result = method.invoke(proxiedObject, args);
+            } catch(InvocationTargetException e) {
+                // rethrow the original exception, not InvocationTargetException
+                throw e.getCause();
             } finally {
                 contextSetupProvider.reset(contextHandleForReset);
                 if (transactionSetupProvider != null) {


### PR DESCRIPTION
The previous implementation threw InvocationTargetException in contextual call. The new implementation throws the original exception, which makes it easier to understand the chain of causes of the exceptions.

In TCK, this passes the assert in ManagedScheduledExecutorDefinitionServlet.testCompletedFutureMSE: https://github.com/jakartaee/concurrency/blob/master/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionServlet.java#L229