### PR TITLE
Switch to source:jar-no-fork in its default phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,9 +285,8 @@
                 <executions>
                     <execution>
                         <id>attach-sources</id>
-                        <phase>validate</phase>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
https://maven.apache.org/plugins/maven-source-plugin/jar-no-fork-mojo.html:

> 1. Binds by default to the [lifecycle phase](https://maven.apache.org/ref/current/maven-core/lifecycles.html): package.

> 2. This goal functions the same as the jar goal but does not fork the build and is suitable for attaching to the build lifecycle.