### PR TITLE
Fix @Asynchronous returned CompletableFuture cancellation

### DIFF
--- a/src/main/java/org/glassfish/concurro/cdi/asynchronous/AsynchronousInterceptor.java
+++ b/src/main/java/org/glassfish/concurro/cdi/asynchronous/AsynchronousInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2024 Payara Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
@@ -118,16 +118,16 @@ public class AsynchronousInterceptor {
                     method);
                 resultFuture.cancel(true);
             }
-            return;
+        } else {
+            // The method returned a different future; complete resultFuture when it completes.
+            returnedFuture.whenComplete((value, throwable) -> {
+                if (throwable != null) {
+                    resultFuture.completeExceptionally(throwable);
+                } else {
+                    resultFuture.complete(value);
+                }
+            });
         }
-        // The method returned a different future; complete resultFuture when it completes.
-        returnedFuture.whenComplete((value, throwable) -> {
-            if (throwable != null) {
-                resultFuture.completeExceptionally(throwable);
-            } else {
-                resultFuture.complete(value);
-            }
-        });
     }
 
     private static <T> T lookupMES(Class<T> cls, String executor, String methodName) throws RejectedExecutionException {

--- a/src/main/java/org/glassfish/concurro/cdi/asynchronous/AsynchronousInterceptor.java
+++ b/src/main/java/org/glassfish/concurro/cdi/asynchronous/AsynchronousInterceptor.java
@@ -31,7 +31,6 @@ import java.lang.reflect.Method;
 import java.time.ZoneId;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Consumer;
@@ -76,33 +75,59 @@ public class AsynchronousInterceptor {
         CompletableFuture<Object> resultFuture = new ManagedCompletableFuture<>(mes);
         mes.submit(() -> {
             Asynchronous.Result.setFuture(resultFuture);
-            CompletableFuture<Object> returnedFuture = resultFuture;
             try {
-                // the asynchronous method is responsible for calling Asynchronous.Result.complete()
-                returnedFuture = (CompletableFuture<Object>) context.proceed();
+                // The asynchronous method either completes Asynchronous.Result and returns it,
+                // or returns a different CompletableFuture instance.
+                CompletableFuture<Object> returnedFuture = (CompletableFuture<Object>) context.proceed();
+                completeResultFuture(method, resultFuture, returnedFuture);
             } catch (Exception ex) {
                 resultFuture.completeExceptionally(ex);
             } finally {
-                // Check if Asynchronous.Result is not completed?
-                if (!returnedFuture.isDone()) {
-                    LOG.log(ERROR,
-                        "Method annotated with @Asynchronous did not call Asynchronous.Result.complete() at its end: {0}",
-                        method);
-                    Asynchronous.Result.getFuture().cancel(true);
-                }
-                if (returnedFuture != Asynchronous.Result.getFuture()) {
-                    // if the asynchronous methods returns a different future, use this to complete the resultFuture
-                    try {
-                        resultFuture.complete(returnedFuture.get());
-                    } catch (InterruptedException | ExecutionException e) {
-                        resultFuture.completeExceptionally(e);
-                    }
-                }
                 // cleanup after asynchronous call
                 Asynchronous.Result.setFuture(null);
             }
         });
         return resultFuture;
+    }
+
+    /**
+     * Bridges the future returned by an {@code @Asynchronous} method to the {@code resultFuture}
+     * handed to the caller.
+     * <p>
+     * Two cases are supported per the Jakarta Concurrency specification:
+     * <ul>
+     * <li>The method completes {@link Asynchronous.Result} and returns it (the same instance as
+     * {@code resultFuture}). In that case the result future is already completed; if it is not, the
+     * method forgot to call {@code Asynchronous.Result.complete()} and the result future is
+     * cancelled.</li>
+     * <li>The method returns a <em>different</em> {@link CompletableFuture}. Its completion (value or
+     * exception) is propagated to {@code resultFuture} without blocking the executor thread.</li>
+     * </ul>
+     *
+     * @param method the intercepted method, used for diagnostics only
+     * @param resultFuture the future returned to the caller (also bound to {@link Asynchronous.Result})
+     * @param returnedFuture the future returned by the method body
+     */
+    static void completeResultFuture(Method method, CompletableFuture<Object> resultFuture,
+            CompletableFuture<Object> returnedFuture) {
+        if (returnedFuture == resultFuture) {
+            // The method was expected to complete Asynchronous.Result itself.
+            if (!returnedFuture.isDone()) {
+                LOG.log(ERROR,
+                    "Method annotated with @Asynchronous did not call Asynchronous.Result.complete() at its end: {0}",
+                    method);
+                resultFuture.cancel(true);
+            }
+            return;
+        }
+        // The method returned a different future; complete resultFuture when it completes.
+        returnedFuture.whenComplete((value, throwable) -> {
+            if (throwable != null) {
+                resultFuture.completeExceptionally(throwable);
+            } else {
+                resultFuture.complete(value);
+            }
+        });
     }
 
     private static <T> T lookupMES(Class<T> cls, String executor, String methodName) throws RejectedExecutionException {

--- a/src/test/java/org/glassfish/concurro/cdi/asynchronous/AsynchronousInterceptorTest.java
+++ b/src/test/java/org/glassfish/concurro/cdi/asynchronous/AsynchronousInterceptorTest.java
@@ -16,9 +16,94 @@
 
 package org.glassfish.concurro.cdi.asynchronous;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 import org.junit.jupiter.api.Test;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class AsynchronousInterceptorTest {
+
+    /**
+     * Regression test for <a href="https://github.com/eclipse-ee4j/glassfish/issues/24203">#24203</a>:
+     * when an {@code @Asynchronous} method returns a <em>different</em>, not-yet-completed
+     * CompletableFuture, the result future handed to the caller must not be cancelled. It must be
+     * completed with the same result once the returned future completes.
+     */
+    @Test
+    public void differentNotYetCompletedFutureIsBridgedNotCancelled() throws Exception {
+        CompletableFuture<Object> resultFuture = new CompletableFuture<>();
+        CompletableFuture<Object> returnedFuture = new CompletableFuture<>();
+
+        AsynchronousInterceptor.completeResultFuture(anyMethod(), resultFuture, returnedFuture);
+
+        // The returned future is still running: the result future must stay pending, not be cancelled.
+        assertFalse(resultFuture.isDone(), "result future must not be completed yet");
+        assertFalse(resultFuture.isCancelled(), "result future must not be cancelled");
+
+        returnedFuture.complete("hello");
+
+        assertEquals("hello", resultFuture.get(5, SECONDS));
+        assertFalse(resultFuture.isCancelled());
+    }
+
+    @Test
+    public void differentFutureExceptionIsPropagated() {
+        CompletableFuture<Object> resultFuture = new CompletableFuture<>();
+        CompletableFuture<Object> returnedFuture = new CompletableFuture<>();
+
+        AsynchronousInterceptor.completeResultFuture(anyMethod(), resultFuture, returnedFuture);
+
+        IllegalStateException failure = new IllegalStateException("boom");
+        returnedFuture.completeExceptionally(failure);
+
+        ExecutionException thrown = assertThrows(ExecutionException.class, resultFuture::get);
+        assertSame(failure, thrown.getCause());
+        assertFalse(resultFuture.isCancelled());
+    }
+
+    @Test
+    public void alreadyCompletedDifferentFutureCompletesResult() throws Exception {
+        CompletableFuture<Object> resultFuture = new CompletableFuture<>();
+        CompletableFuture<Object> returnedFuture = CompletableFuture.completedFuture("done");
+
+        AsynchronousInterceptor.completeResultFuture(anyMethod(), resultFuture, returnedFuture);
+
+        assertEquals("done", resultFuture.get(5, SECONDS));
+    }
+
+    @Test
+    public void sameFutureCompletedByMethodIsLeftIntact() throws Exception {
+        CompletableFuture<Object> resultFuture = new CompletableFuture<>();
+        resultFuture.complete("via Asynchronous.Result");
+
+        AsynchronousInterceptor.completeResultFuture(anyMethod(), resultFuture, resultFuture);
+
+        assertEquals("via Asynchronous.Result", resultFuture.get(5, SECONDS));
+        assertFalse(resultFuture.isCancelled());
+    }
+
+    @Test
+    public void sameFutureNotCompletedByMethodIsCancelled() {
+        CompletableFuture<Object> resultFuture = new CompletableFuture<>();
+
+        AsynchronousInterceptor.completeResultFuture(anyMethod(), resultFuture, resultFuture);
+
+        // The method forgot to call Asynchronous.Result.complete(): the result future is cancelled.
+        assertTrue(resultFuture.isCancelled());
+    }
+
+    private static java.lang.reflect.Method anyMethod() {
+        // Any method works: it is only used for diagnostic logging.
+        return AsynchronousInterceptorTest.class.getDeclaredMethods()[0];
+    }
+
     @Test
     public void testGettingCronTriggerFromScheduleWithCronExpression() {
         var scheduleWithCronExpression = ScheduleStub.newScheduleWithCronExpression("*/5 * * * * *");


### PR DESCRIPTION
@
## Problem

When a Jakarta Concurrency `@Asynchronous` method returns a **different** `CompletableFuture` (the spec-supported alternative to completing `Asynchronous.Result`), the caller receives a `CancellationException` instead of the result.

Reproducer from the issue:

```java
@Asynchronous
public CompletableFuture<List<Todo>> getAllTodosAsync() {
    return executorService.supplyAsync(() -> em.createQuery(...).getResultList());
}
```

The server logs `Method annotated with @Asynchronous did not call Asynchronous.Result.complete()` and the returned future is cancelled.

## Root cause

In `AsynchronousInterceptor.executeDirectly(...)`, the `finally` block called `returnedFuture.isDone()` on the future returned by the method. When the method returns its own (still-running) future, `isDone()` is `false`, so the code:

1. logged the misleading "did not call `Asynchronous.Result.complete()`" error, and
2. **cancelled** the result future already handed to the caller → `CancellationException`.

It then also blocked an executor thread on `returnedFuture.get()`.

The `isDone()` check is only meaningful for the case where the method returns `Asynchronous.Result.getFuture()` itself; it was applied unconditionally, conflating it with the "returns a different future" case.

## Fix

Extract the completion logic into `completeResultFuture(...)` that distinguishes the two spec-supported cases up front:

- **Returns `Asynchronous.Result` (same instance):** if it is not completed, the method forgot to call `complete()` — log and cancel (unchanged behavior).
- **Returns a different `CompletableFuture`:** bridge it non-blockingly via `whenComplete`, propagating its value or exception to the result future. No cancellation, no blocked executor thread.

## Tests

Added 5 unit tests in `AsynchronousInterceptorTest` covering: a different not-yet-completed future is bridged (regression for the issue), exception propagation, an already-completed different future, the same-future completed path, and the same-future "forgot to complete" cancellation path. All pass.

Fixes #188
Fixes eclipse-ee4j/glassfish#24203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@